### PR TITLE
Fixed a silly syntax error in `linux.py`

### DIFF
--- a/xerox/linux.py
+++ b/xerox/linux.py
@@ -20,7 +20,7 @@ def copy(string):
 def paste():
     """Returns system clipboard contents."""
     try:
-        return subprocess.Popen(["xclip", "-selection", "clipboard", "-o"], stdout=subprocess.PIPE).communicate()[0]).decode("utf-8")
+        return subprocess.Popen(["xclip", "-selection", "clipboard", "-o"], stdout=subprocess.PIPE).communicate()[0].decode("utf-8")
     except OSError as why:
         raise XclipNotFound
 


### PR DESCRIPTION
I didn't notice that this would get a syntax error under linux, but it came up when I reinstalled xerox from PyPi. There was an spare close-parentheses there. 

Sorry!
