### PR TITLE
fallback to tkinter if pywin32 is missing

### DIFF
--- a/xerox/base.py
+++ b/xerox/base.py
@@ -17,3 +17,6 @@ class XclipNotFound(ToolNotFound):
        On Ubuntu,
        $ apt-get install xclip
     """
+class TkinterNotFound(ToolNotFound):
+    """Tkinter must be installed"""
+

--- a/xerox/core.py
+++ b/xerox/core.py
@@ -12,7 +12,10 @@ elif sys.platform.startswith('linux'):
     from .linux import *
     
 elif sys.platform == 'win32':
-    from .win import *
+    try:
+        from .win import *
+    except:
+        from .tkinter import *
 
 elif sys.platform == 'cli':
     from .cli import *

--- a/xerox/tkinter.py
+++ b/xerox/tkinter.py
@@ -1,0 +1,28 @@
+"""
+Copy + Paste in Windows, Linux or Mac
+
+found @ http://code.activestate.com/recipes/150115/
+"""
+
+from .base import * 
+
+try:
+    from Tkinter import Tk
+except ImportError as why:
+    raise TkinterNotFound
+
+def copy(string): 
+    """Copy given string into system clipboard."""
+    window = Tk()
+    window.withdraw()
+    window.clipboard_clear()
+    window.clipboard_append(string)
+    window.destroy()
+    return
+    
+def paste():
+    """Returns system clipboard contents."""
+    window = Tk()
+    window.withdraw()
+    d = window.selection_get(selection = 'CLIPBOARD')
+    return d 


### PR DESCRIPTION
Not sure how you want to intergrate this as it could potentially be a fallback for mac and linux too. but tinker.py is good to go