### PR TITLE
Python 3 fix

### DIFF
--- a/xerox/core.py
+++ b/xerox/core.py
@@ -8,7 +8,7 @@ __license__ = 'MIT'
 if sys.platform == 'darwin':
     from .darwin import *
     
-elif sys.platform == 'linux2':
+elif sys.platform.startswith('linux'):
     from .linux import *
     
 elif sys.platform == 'win32':


### PR DESCRIPTION
In Python 3, sys.platform is 'linux' rather than 'linux2'.
