### PR TITLE
Fixed unicode copy in Windows

### DIFF
--- a/xerox/win.py
+++ b/xerox/win.py
@@ -17,7 +17,7 @@ def copy(string):
 
     clip.OpenClipboard()
     clip.EmptyClipboard()
-    clip.SetClipboardData(1, string) 
+    clip.SetClipboardData(win32con.CF_UNICODETEXT, string) 
     clip.CloseClipboard()
 
     return


### PR DESCRIPTION
The constant 1 passed to SetClipboardData was wrong.
