### PR TITLE
Fix some UnicodeDecodeErrors on python3 in xerox.paste()

### DIFF
--- a/test_xerox.py
+++ b/test_xerox.py
@@ -3,10 +3,21 @@
 
 import xerox
 import unittest
+import sys
+
 
 class BasicAPITestCase(unittest.TestCase):
     def setUp(self):
-        self.text = 'And now for something completely different.'
+        """
+        Note the apostrophe below is actually Unicode U+2019 'RIGHT SINGLE QUOTATION MARK', to
+        test for unicode decode errors
+        """
+        if sys.version_info >= (3, 0):
+            self.text = 'And now it’s time for something completely different.'
+        else:
+            #Python <= 3.3 doesn't support u'' literals, so use the unicode constructor instead
+            #self.text = u'And now it’s time for something completely different.'
+            self.text = unicode('And now it\xe2\x80\x99s time for something completely different.', encoding='utf-8')
         
     def test_copy(self):
         xerox.copy(self.text)

--- a/xerox/darwin.py
+++ b/xerox/darwin.py
@@ -5,6 +5,7 @@
 
 
 import subprocess
+import os
 
 from .base import *
 
@@ -23,6 +24,9 @@ def copy(string):
 def paste():
     """Returns system clipboard contents."""
     try:
+        #Tell the IO system to decode IPC IO with utf-8,
+        #to prevent UnicodeDecodeErrors on python3
+        os.environ['LANG'] = 'en_US.utf-8'
         return subprocess.Popen(
             ['pbpaste'], stdout=subprocess.PIPE).communicate()[0].decode('utf-8')
 


### PR DESCRIPTION
I encountered some UnicodeDecodeErrors when running xerox.paste() in python3 with unicode data in the clipboard. This PR should fix the issue, and work both for python2 and python3. Tests included.
