### PR TITLE
Allow optional X selection copy/paste on Linux

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,16 @@ And to paste: ::
 	>>> xerox.paste()
 	u'some string'
 
+On Linux you can optionally also copy into the X selection clipboard for
+middle-click-paste capability: ::
+
+    xerox.copy(u'Some string', xsel=True)
+
+And you can choose to paste from the X selection rather than the system
+clipboard: ::
+
+    xerox.paste(xsel=True)
+
 And, that's it.
 
 Command Line

--- a/test_xerox.py
+++ b/test_xerox.py
@@ -4,6 +4,7 @@
 import xerox
 import unittest
 import sys
+import time
 
 
 class BasicAPITestCase(unittest.TestCase):
@@ -13,11 +14,11 @@ class BasicAPITestCase(unittest.TestCase):
         test for unicode decode errors
         """
         if sys.version_info >= (3, 0):
-            self.text = 'And now it’s time for something completely different.'
+            self.text = 'And now it’s time for something completely different. ' + str(time.time())
         else:
             #Python <= 3.3 doesn't support u'' literals, so use the unicode constructor instead
             #self.text = u'And now it’s time for something completely different.'
-            self.text = unicode('And now it\xe2\x80\x99s time for something completely different.', encoding='utf-8')
+            self.text = unicode('And now it\xe2\x80\x99s time for something completely different. ' + str(time.time()), encoding='utf-8')
         
     def test_copy(self):
         xerox.copy(self.text)
@@ -26,7 +27,14 @@ class BasicAPITestCase(unittest.TestCase):
     def test_paste(self):
         xerox.copy(self.text)
         self.assertEqual(xerox.paste(), self.text)
-        
+
+    def test_copy_xsel(self):
+        if not sys.platform.startswith('linux'):
+            return
+        xerox.copy(self.text, xsel=True)
+        # Check that we can copy from the clipboard and the X selection
+        self.assertEqual(xerox.paste(), self.text)
+        self.assertEqual(xerox.paste(xsel=True), self.text)
         
 if __name__ == '__main__':
     unittest.main()

--- a/xerox/darwin.py
+++ b/xerox/darwin.py
@@ -10,7 +10,7 @@ import os
 from .base import *
 
 
-def copy(string):
+def copy(string, **kwargs):
     """Copy given string into system clipboard."""
     try:
         subprocess.Popen(['pbcopy'], stdin=subprocess.PIPE).communicate(
@@ -20,8 +20,7 @@ def copy(string):
 
     return
 
-
-def paste():
+def paste(**kwargs):
     """Returns system clipboard contents."""
     try:
         #Tell the IO system to decode IPC IO with utf-8,

--- a/xerox/linux.py
+++ b/xerox/linux.py
@@ -7,20 +7,25 @@ import subprocess
 from .base import *
 
 
-def copy(string):
-    """Copy given string into system clipboard."""
+def copy(string, xsel=False):
+    """Copy given string into system clipboard. If 'xsel' is True, this
+    will also copy into the primary x selection for middle click."""
     try:
         _cmd = ["xclip", "-selection", "clipboard"]
         subprocess.Popen(_cmd, stdin=subprocess.PIPE).communicate(
                 string.encode('utf-8'))
-        return
+        if xsel:
+            _cmd = ["xclip", "-selection", "primary"]
+            subprocess.Popen(_cmd, stdin=subprocess.PIPE).communicate(
+                    string.encode('utf-8'))
     except OSError as why:
         raise XclipNotFound
-    
-def paste():
+
+def paste(xsel=False):
     """Returns system clipboard contents."""
+    selection = "primary" if xsel else "clipboard"
     try:
-        return subprocess.Popen(["xclip", "-selection", "clipboard", "-o"], stdout=subprocess.PIPE).communicate()[0].decode("utf-8")
+        return subprocess.Popen(["xclip", "-selection", selection, "-o"], stdout=subprocess.PIPE).communicate()[0].decode("utf-8")
     except OSError as why:
         raise XclipNotFound
 

--- a/xerox/win.py
+++ b/xerox/win.py
@@ -12,7 +12,7 @@ except ImportError as why:
     raise Pywin32NotFound
 
 
-def copy(string): 
+def copy(string, **kwargs):
     """Copy given string into system clipboard."""
 
     clip.OpenClipboard()
@@ -21,9 +21,8 @@ def copy(string):
     clip.CloseClipboard()
 
     return
-    
 
-def paste():
+def paste(**kwargs):
     """Returns system clipboard contents."""
 
     clip.OpenClipboard() 


### PR DESCRIPTION
As an X11 greybeard I use select-to-copy/middle-click-to-paste more than the standard clipboard. This patch lets us specify 'xsel=True' as an optional argument to copy() and paste() to enable that behaviour.

- Add optional argument to also copy into the X primary selection
  for middle-click copy/paste ability on Linux.
- Use unique text for each test run