### PR TITLE
Ensure Unicode is returned for Windows

### DIFF
--- a/xerox/win.py
+++ b/xerox/win.py
@@ -27,7 +27,7 @@ def paste():
     """Returns system clipboard contents."""
 
     clip.OpenClipboard() 
-    d = clip.GetClipboardData(win32con.CF_TEXT) 
+    d = clip.GetClipboardData(win32con.CF_UNICODETEXT)
     clip.CloseClipboard() 
     return d 
 


### PR DESCRIPTION
unittest now passes and non-ascii characters are handled correctly if they are found in the clipboard.