### PR TITLE
Fix paste function to return unicode (Windows)

### DIFF
--- a/test_xerox.py
+++ b/test_xerox.py
@@ -33,6 +33,10 @@ class BasicAPITestCase(unittest.TestCase):
         self.assertIsInstance(got, str)
         self.assertEqual(got, self.text)
 
+    def test_no_unicode(self):
+        with self.assertRaises(ValueError):
+            xerox.copy(b'This is a byte string.')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_xerox.py
+++ b/test_xerox.py
@@ -4,6 +4,10 @@
 import xerox
 import unittest
 import sys
+import time
+
+if sys.version_info[0] < 3:
+    str = unicode
 
 
 class BasicAPITestCase(unittest.TestCase):
@@ -12,21 +16,23 @@ class BasicAPITestCase(unittest.TestCase):
         Note the apostrophe below is actually Unicode U+2019 'RIGHT SINGLE QUOTATION MARK', to
         test for unicode decode errors
         """
-        if sys.version_info >= (3, 0):
-            self.text = 'And now it’s time for something completely different.'
-        else:
-            #Python <= 3.3 doesn't support u'' literals, so use the unicode constructor instead
-            #self.text = u'And now it’s time for something completely different.'
-            self.text = unicode('And now it\xe2\x80\x99s time for something completely different.', encoding='utf-8')
-        
-    def test_copy(self):
+        # unicode test string
+        self.text = b'And now it\xe2\x80\x99s time for something completely different.'.decode(
+            'utf-8')
+
+        # add current time (to avoid problems where the clipboard content was correct for the wrong reason)
+        self.text += str(time.time())
+
+    def test_copy_and_paste(self):
+        # copy
+        self.assertIsInstance(self.text, str)
         xerox.copy(self.text)
-        self.assertEqual(xerox.paste(), self.text)
-        
-    def test_paste(self):
-        xerox.copy(self.text)
-        self.assertEqual(xerox.paste(), self.text)
-        
-        
+
+        # paste
+        got = xerox.paste()
+        self.assertIsInstance(got, str)
+        self.assertEqual(got, self.text)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/xerox/base.py
+++ b/xerox/base.py
@@ -1,16 +1,27 @@
 # -*- coding: utf-8 -*-
+import sys
+
+if sys.version_info[0] < 3:
+    unicode_type = unicode
+else:
+    unicode_type = str
+
 
 class ToolNotFound(Exception):
     """A needed tool was not found."""
-    
+
+
 class Pywin32NotFound(ToolNotFound):
     """PyWin32 must be installed."""
+
 
 class ClrNotFound(ToolNotFound):
     """clr must be installed."""
 
+
 class XcodeNotFound(ToolNotFound):
     """xcode must be installed."""
+
 
 class XclipNotFound(ToolNotFound):
     """xclip must be installed.

--- a/xerox/darwin.py
+++ b/xerox/darwin.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
-
 """ Copy + Paste in OS X
 """
-
 
 import subprocess
 import os
@@ -12,9 +10,13 @@ from .base import *
 
 def copy(string):
     """Copy given string into system clipboard."""
+    if not isinstance(string, unicode_type):
+        raise ValueError('Expected unicode string, got bytes.')
+
     try:
-        subprocess.Popen(['pbcopy'], stdin=subprocess.PIPE).communicate(
-                string.encode("utf-8"))
+        subprocess.Popen(['pbcopy'],
+                         stdin=subprocess.PIPE).communicate(
+                             string.encode("utf-8"))
     except OSError as why:
         raise XcodeNotFound
 
@@ -28,8 +30,8 @@ def paste():
         #to prevent UnicodeDecodeErrors on python3
         os.environ['LANG'] = 'en_US.utf-8'
         return subprocess.Popen(
-            ['pbpaste'], stdout=subprocess.PIPE).communicate()[0].decode('utf-8')
+            ['pbpaste'],
+            stdout=subprocess.PIPE).communicate()[0].decode('utf-8')
 
     except OSError as why:
         raise XcodeNotFound
-

--- a/xerox/linux.py
+++ b/xerox/linux.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 """ Copy + Paste in Linux
 """
 
@@ -9,18 +8,24 @@ from .base import *
 
 def copy(string):
     """Copy given string into system clipboard."""
+    if not isinstance(string, unicode_type):
+        raise ValueError('Expected unicode string, got bytes.')
+
     try:
         _cmd = ["xclip", "-selection", "clipboard"]
-        subprocess.Popen(_cmd, stdin=subprocess.PIPE).communicate(
-                string.encode('utf-8'))
+        subprocess.Popen(_cmd,
+                         stdin=subprocess.PIPE).communicate(
+                             string.encode('utf-8'))
         return
     except OSError as why:
         raise XclipNotFound
-    
+
+
 def paste():
     """Returns system clipboard contents."""
     try:
-        return subprocess.Popen(["xclip", "-selection", "clipboard", "-o"], stdout=subprocess.PIPE).communicate()[0].decode("utf-8")
+        return subprocess.Popen(
+            ["xclip", "-selection", "clipboard", "-o"],
+            stdout=subprocess.PIPE).communicate()[0].decode("utf-8")
     except OSError as why:
         raise XclipNotFound
-

--- a/xerox/win.py
+++ b/xerox/win.py
@@ -3,7 +3,7 @@
 
 # found @ http://code.activestate.com/recipes/150115/
 
-from .base import * 
+from .base import *
 
 try:
     import win32clipboard as clip
@@ -12,23 +12,21 @@ except ImportError as why:
     raise Pywin32NotFound
 
 
-def copy(string): 
+def copy(string):
     """Copy given string into system clipboard."""
 
     clip.OpenClipboard()
     clip.EmptyClipboard()
-    clip.SetClipboardData(win32con.CF_UNICODETEXT, string) 
+    clip.SetClipboardData(win32con.CF_UNICODETEXT, string)
     clip.CloseClipboard()
 
     return
-    
+
 
 def paste():
     """Returns system clipboard contents."""
 
-    clip.OpenClipboard() 
-    d = clip.GetClipboardData(win32con.CF_TEXT) 
-    clip.CloseClipboard() 
-    return d 
-
- 
+    clip.OpenClipboard()
+    d = clip.GetClipboardData(win32con.CF_UNICODETEXT)
+    clip.CloseClipboard()
+    return d

--- a/xerox/win.py
+++ b/xerox/win.py
@@ -3,6 +3,8 @@
 
 # found @ http://code.activestate.com/recipes/150115/
 
+import sys
+
 from .base import *
 
 try:
@@ -14,6 +16,9 @@ except ImportError as why:
 
 def copy(string):
     """Copy given string into system clipboard."""
+
+    if not isinstance(string, unicode_type):
+        raise ValueError('Expected unicode string, got bytes.')
 
     clip.OpenClipboard()
     clip.EmptyClipboard()


### PR DESCRIPTION
The patch uses `win32con.CF_UNICODETEXT` rather than `win32con.CF_TEXT` in `paste()` so that xerox always returns a unicode string (i.e., `unicode`/`str` instances). I have also adjusted the unit test.