### PR TITLE
Fix detecting piped input

### DIFF
--- a/xerox/__init__.py
+++ b/xerox/__init__.py
@@ -1,12 +1,15 @@
 from .core import *
 
 import sys
+import os
+import stat
 
 def main():
     """ Entry point for cli. """
+    mode = os.fstat(0).st_mode
     if sys.argv[1:]:  # called with input arguments
         copy(' '.join(sys.argv[1:]))
-    elif not sys.stdin.isatty():  # piped in input
+    elif stat.S_ISFIFO(mode) or stat.S_ISREG(mode):  # piped in input
         copy('\n'.join(sys.stdin.readlines()))
     else:  # paste output
         print(paste())


### PR DESCRIPTION
Fixes case when used inside Python script which is not run from a tty, I bet there are a few other cases it fixes as well.

# Files

isatty_test1.py (executable):
```py
#!/usr/bin/env python3

import sys, stat, os

mode = os.fstat(0).st_mode
print(mode)

print("isatty", sys.stdin.isatty())

print("isfifo", stat.S_ISFIFO(mode))
print("isreg", stat.S_ISREG(mode))
```

isatty_test2.py
```py
import subprocess
p = subprocess.Popen(['./isatty_test1.py'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
print(p.communicate())
```

isatty_test3.py (executable - same as test2 but writes to a file so that we can run it outside a tty):
```py
#!/usr/bin/env python3

import subprocess
p = subprocess.Popen(['./isatty_test1.py'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
with open("./test3.out", "w") as f:
    print(p.communicate(), file=f)
```

# Tests

In a terminal `./isatty_test1.py`
Output:
```
8592
isatty True
isfifo False
isreg False
```

In a terminal `python ./isatty_test2.py`
Output:
```
('8592\nisatty True\nisfifo False\nisreg False\n', '')
```

Running isatty_test3.py as an executable from my file manager (note that no input was piped in, but the first output doesn't match xerox's current expectations)
Output (test3.out):
```
(b'8630\nisatty False\nisfifo False\nisreg False\n', b'')
```

In terminal `./isatty_test1.py < test3.out`
Output:
```
33188
isatty False
isfifo False
isreg True
```

In a terminal `cat ./isatty_test1.py | ./isatty_test1.py`
Output:
```
4480
isatty False
isfifo True
isreg False
```