### PR TITLE
Handle empty clipboard or non-text under Windows

### DIFF
--- a/xerox/win.py
+++ b/xerox/win.py
@@ -26,7 +26,12 @@ def paste(**kwargs):
     """Returns system clipboard contents."""
 
     clip.OpenClipboard() 
-    d = clip.GetClipboardData(win32con.CF_UNICODETEXT)
+    try:
+        d = clip.GetClipboardData(win32con.CF_UNICODETEXT)
+    except TypeError:
+        # Handle, "Specified clipboard format is not available"
+        # Either clipboard is empty or does NOT contain text
+        d = ''
     clip.CloseClipboard() 
     return d 
 


### PR DESCRIPTION
On a newly booted Windows machine clipboard will be empty (or if clipboard explicitly cleared).

Test case:

    #!/usr/bin/env python


    import os
    import sys

    import win32clipboard
    import win32con

    import xerox

    win32clipboard.OpenClipboard() 
    x = win32clipboard.EmptyClipboard()
    # next get will raise; TypeError: Specified clipboard format is not available
    win32clipboard.CloseClipboard() 
    print type(x)
    print repr(x)
    print '-' * 65

    x = xerox.paste()
    print type(x)
    print repr(x)
