### PR TITLE
Remove piped input newline

### DIFF
--- a/xerox/__init__.py
+++ b/xerox/__init__.py
@@ -1,12 +1,13 @@
 from .core import *
 
 import sys
+import os
 
 def main():
     """ Entry point for cli. """
     if sys.argv[1:]:  # called with input arguments
         copy(' '.join(sys.argv[1:]))
     elif not sys.stdin.isatty():  # piped in input
-        copy('\n'.join(sys.stdin.readlines()))
+        copy(''.join(sys.stdin.readlines()).rstrip(os.linesep))
     else:  # paste output
         print(paste())

--- a/xerox/__init__.py
+++ b/xerox/__init__.py
@@ -1,13 +1,13 @@
 from .core import *
 
 import sys
-import os
+
 
 def main():
     """ Entry point for cli. """
     if sys.argv[1:]:  # called with input arguments
         copy(' '.join(sys.argv[1:]))
     elif not sys.stdin.isatty():  # piped in input
-        copy(''.join(sys.stdin.readlines()).rstrip(os.linesep))
+        copy(''.join(sys.stdin.readlines()).rstrip('\n'))
     else:  # paste output
         print(paste())


### PR DESCRIPTION
The change joins lines with "" instead of \n and removes the trailing \n.
 Now piped input is formatted the same as xerox somestring.
# **Example:**
```bash
echo Hi | xerox
```
## Before changes:
```bash
xerox
> Hi

>
```
## After changes:
```bash
xerox
> Hi
```
